### PR TITLE
[FIX] Vinculo Antigo no contrato novas situações

### DIFF
--- a/sped_esocial/models/inherited_hr_contract.py
+++ b/sped_esocial/models/inherited_hr_contract.py
@@ -182,6 +182,10 @@ class HrContract(models.Model):
         string='Precisa atualizar dados?',
         related='sped_esocial_alterar_contrato_autonomo_id.precisa_atualizar',
     )
+    admission_type_code = fields.Char(
+        string='Código do tipo da admissão',
+        related='admission_type_id.code'
+    )
 
     @api.multi
     def ativar_contrato(self):

--- a/sped_esocial/views/inherited_hr_contract.xml
+++ b/sped_esocial/views/inherited_hr_contract.xml
@@ -11,7 +11,21 @@
                 <!--<field name="categoria" position="before">-->
                     <!--<field name="evento_esocial" invisible="True" />-->
                 <!--</field>-->
-
+                <field name="admission_type_id" position="after">
+                    <field name="admission_type_code" invisible="1"/>
+                </field>
+                <group name="vinculo_anterior" position="attributes">
+                    <attribute name="attrs">{'invisible': [('admission_type_code', '=', '1')]}</attribute>
+                </group>
+                <field name="cnpj_empregador_anterior" position="attributes">
+                    <attribute name="attrs">{'required': [('admission_type_code', '!=', '1')]}</attribute>
+                </field>
+                <field name="matricula_anterior" position="attributes">
+                    <attribute name="attrs">{'required': [('admission_type_code', '!=', '1')]}</attribute>
+                </field>
+                <field name="data_admissao_anterior" position="attributes">
+                    <attribute name="attrs">{'required': [('admission_type_code', '!=', '1')]}</attribute>
+                </field>
                 <xpath expr="//page[@string='Alterações Contratuais']" position="after">
 
                     <!-- Esocial para trabalhadores com Vinculo Registro S2200-->


### PR DESCRIPTION
- Campos do grupo 'Vinculo Antigo' somente fica visível se o tipo de
adimissão não for '1 - Admissão', em caso negativo o grupo fica visivel
e alguns de seus campos tornam-se obrigatórios de preenchimento.

Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------

-
-
-

Comportamento atual antes do PR:
--------------------------------


Comportamento esperado depois do PR:
------------------------------------





- [ ] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute