### PR TITLE
Fix/alteracao modo expressao kpi

### DIFF
--- a/l10n_br_contabilidade/models/mis_report.py
+++ b/l10n_br_contabilidade/models/mis_report.py
@@ -4,7 +4,7 @@
 
 import re
 
-from openerp import api, fields, models, _
+from openerp import api, fields, models, _, exceptions
 from openerp.addons.mis_builder.models.aep import \
     AccountingExpressionProcessor as AEP
 
@@ -42,6 +42,10 @@ class MisReport(models.Model):
         for kpi in self.kpi_ids:
 
             # Limpando o domain existente
+            if not kpi.expression:
+                raise exceptions.Warning(_(
+                    u'Erro no KPI {} ({})!\n'
+                    u'Expressão inválida.'.format(kpi.name, kpi.description)))
             kpi_expression = kpi.expression.replace(domain, '')
 
             # Inserindo o novo domain na expressão

--- a/l10n_br_contabilidade/models/mis_report.py
+++ b/l10n_br_contabilidade/models/mis_report.py
@@ -52,7 +52,8 @@ class MisReport(models.Model):
             if not kpi.incluir_lancamentos_de_fechamento:
                 kpi_expression = re.sub(r'(\w+\[[\d.,\s]+\])', '\\1' + domain,
                                         kpi_expression)
-            kpi.expression = kpi_expression
+            if kpi.expression != kpi_expression:
+                kpi.expression = kpi_expression
             aep.parse_expr(kpi.expression)
 
         aep.done_parsing(root_account)

--- a/l10n_br_contabilidade/models/mis_report_kpi.py
+++ b/l10n_br_contabilidade/models/mis_report_kpi.py
@@ -95,6 +95,12 @@ class MisReportKpi(models.Model):
             self.expression_mode = 'manual'
 
     @api.one
+    @api.onchange('expression_mode')
+    def onchange_report_mode(self):
+        if self.expression_mode == 'manual':
+            self.account_ids = False
+
+    @api.one
     @api.constrains('account_ids')
     def _constrains_report_mode(self):
         if self.report_id.report_mode == 'contabil':


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------

- 
-
-

Comportamento atual antes do PR:
--------------------------------
Ao criar um KPI no modo contábil e depois alterando para o modo manual sem remover as contas vinculadas, ao gerar a visualização desse relatorio é acusado um erro que não descreve a situação.

Comportamento esperado depois do PR:
------------------------------------
Ao alterar o modo de expressão de contábil para manual, as contas vinculadas ao KPI são desvinculadas do KPI. A visualização desse relatório não é interrompida.




- [ ] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute