### PR TITLE
[IMP] Setar o job_id no contrato e não no funcionário.

### DIFF
--- a/l10n_br_hr/model/hr_job.py
+++ b/l10n_br_hr/model/hr_job.py
@@ -8,4 +8,8 @@ from openerp import models, fields
 class HrJob(models.Model):
     _inherit = 'hr.job'
 
-    cbo_id = fields.Many2one('l10n_br_hr.cbo', 'CBO')
+    cbo_id = fields.Many2one(
+        comodel_name='l10n_br_hr.cbo',
+        string='CBO',
+        help='Classificação Brasileira de Ocupações',
+    )

--- a/l10n_br_hr_contract/models/hr_contract.py
+++ b/l10n_br_hr_contract/models/hr_contract.py
@@ -181,3 +181,16 @@ class HrContract(models.Model):
             if record.union_cnpj:
                 if not fiscal.validate_cnpj(record.union_cnpj):
                     raise ValidationError("Invalid union CNPJ!")
+
+    @api.onchange('job_id')
+    def set_job_in_employee(self):
+        """
+        Definir o campo função no funcionário.
+        Caso o funcionário venha a ter um segundo contrato, popular o campo
+        no employee. Caso tenha uma alteração contratual, popular o campo
+        """
+        for record in self:
+            if record.employee_id and \
+                    not record.job_id == record.employee_id.job_id:
+                record.employee_id.with_context(alteracaocontratual=True).\
+                    write({'job_id': record.job_id.id,})

--- a/l10n_br_hr_contract/views/hr_contract_view.xml
+++ b/l10n_br_hr_contract/views/hr_contract_view.xml
@@ -34,7 +34,7 @@
                     <field name="monthly_hours"/>
                     <field name="weekly_hours"/>
                 </xpath>
-
+                
                 <xpath expr="//page[@string='Work Permit']" position="after">
                     <page string="Resignation">
                         <group string="Resignation">


### PR DESCRIPTION
Falta esconder na visão do funcionário o campo job_id

Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------

-
-
-

Comportamento atual antes do PR:
--------------------------------


Comportamento esperado depois do PR:
------------------------------------





- [ ] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute